### PR TITLE
Abort the operation if the lock cannot be acquired

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ FileLockedOperation.prototype.doLockedOperation = function(operation, done) {
   var that = this;
   lockfile.lock(this.lockFilePath, this.opts, function(err) {
     if (err !== undefined) {
-      done(new Error('FileLockedOperation.doLockedOperation: ' +
+      return done(new Error('FileLockedOperation.doLockedOperation: ' +
         err.message));
     }
     operation(function(opError) { that._releaseLock(opError, done); });
@@ -25,7 +25,7 @@ FileLockedOperation.prototype._releaseLock = function(operationError, done) {
     if (err !== undefined) {
       var opErrorMsg = (operationError !== undefined) ?
         operationError.message + '\n' : '';
-      done(new Error(opErrorMsg + 'FileLockedOperation._releaseLock: ' +
+      return done(new Error(opErrorMsg + 'FileLockedOperation._releaseLock: ' +
         err.message));
     }
     done(operationError);

--- a/test/lib/test-helper.js
+++ b/test/lib/test-helper.js
@@ -8,5 +8,9 @@ exports.check = function(done, cb) {
 };
 
 exports.checkN = function(n, done, cb) {
-  return function(err) { if (--n === 0) { exports.check(done, cb)(err); } };
+  var errors = [];
+  return function(err) {
+    if (err) { errors.push(err); }
+    if (--n === 0) { exports.check(done, cb)(errors); }
+  };
 };


### PR DESCRIPTION
Not aborting defeats the whole purpose of the lock, after all...

I wouldn't say this fix is _critical_ at the moment, but the sooner we can deploy it, the better. :-)

cc: @arowla @maya @shawnbot @msecret 
